### PR TITLE
docs: mention stable branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).
 [![Ubuntu](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci.yml)
 [![Windows](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci-windows.yml)
 
+Stable releases are maintained on the `stable` branch and in tagged versions.
+
 ## Prerequisites
 * C++ compiler
 * CMake 2.8 or newer


### PR DESCRIPTION
## Summary
- note that stable releases are available on the `stable` branch and via tags

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d99cb0d8832ca4491cb558e2cd91