### PR TITLE
fix(utils): compute max length without branching

### DIFF
--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -186,7 +186,9 @@ std::array<uint8_t, N> generate_iv_impl() {
 
 bool constant_time_equal(const std::vector<uint8_t> &a,
                          const std::vector<uint8_t> &b) {
-  const std::size_t max_len = std::max(a.size(), b.size());
+  std::size_t max_len = a.size();
+  max_len +=
+      (b.size() - max_len) & static_cast<std::size_t>(-(b.size() > max_len));
   std::size_t diff = a.size() ^ b.size();
   for (std::size_t i = 0; i < max_len; ++i) {
     const uint8_t av = i < a.size() ? a[i] : 0;


### PR DESCRIPTION
## Summary
- avoid data-dependent branching in constant_time_equal by replacing std::max with branchless arithmetic

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b7dbe693f8832c99bad10ccc25bdae