### PR TITLE
docs: clarify constant_time_equal length assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ auto restored =
     utils::decrypt_to_string(encrypted, key, utils::AesMode::CTR, mac_fn);
 ```
 
+### Constant-Time Comparison
+`utils::constant_time_equal` compares byte vectors without leaking
+information through timing, but it assumes the lengths of both inputs are
+public because it checks them and derives a loop bound from the larger size.
+
 ### GCM Helpers
 `encrypt_gcm` and `decrypt_gcm` manage the 12-byte IV, optional additional
 authenticated data (AAD), and the authentication tag produced by GCM.

--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -186,6 +186,8 @@ std::array<uint8_t, N> generate_iv_impl() {
 
 bool constant_time_equal(const std::vector<uint8_t> &a,
                          const std::vector<uint8_t> &b) {
+  // Length comparison and max_len computation are allowed only when the
+  // vector sizes are public and not secret.
   std::size_t max_len = a.size();
   max_len +=
       (b.size() - max_len) & static_cast<std::size_t>(-(b.size() > max_len));


### PR DESCRIPTION
## Summary
- document that `utils::constant_time_equal` only compares lengths when sizes are non-secret
- note in README that the helper assumes input sizes are public

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b7dd7d00cc832c84055ba190165eed