### PR TITLE
docs: mention siphash-hpp project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ CBC doesn't satisfy this condition an exception will be thrown
 These projects can be used together with aescpp:
 
 * [hmac-cpp](https://github.com/NewYaroslav/hmac-cpp) - HMAC for authentication
+* [siphash-hpp](https://github.com/NewYaroslav/siphash-hpp) - header-only SipHash library
 * [obfy](https://github.com/NewYaroslav/obfy) - generate license verification code
 * [Wiki](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
 * [NIST](https://www.nist.gov/publications/advanced-encryption-standard-aes)


### PR DESCRIPTION
## Summary
- reference `siphash-hpp` as a complementary header-only SipHash library in the README

## Testing
- `./setup-hooks.sh`
- `make test` *(fails: docker-compose: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d5e8c2b0832c8aac2b1a7dfe04e0